### PR TITLE
Improving things for runtime and adding `abstractmethod`.

### DIFF
--- a/RadioDetector.py
+++ b/RadioDetector.py
@@ -1,6 +1,10 @@
-class RadioDetector:
-    def detect_radios(self):
-        raise NotImplementedError("Subclasses must implement detect_radios method")
+from abc import ABC, abstractmethod
 
-    def is_radio(self, description):
-        raise NotImplementedError("Subclasses must implement is_radio method")
+class RadioDetector(ABC):
+    @abstractmethod
+    def detect_radios(self):
+        pass
+
+    @abstractmethod
+    def is_radio(self, description: str) -> bool:
+        pass


### PR DESCRIPTION
Hi @PartTimeLegend, this is a synopsis of what I changed,

Added `from abc import ABC` and `abstractmethod`.

This imports the necessary tools from Python's Abstract Base Class (ABC) module.

Changed class `RadioDetector` to class `RadioDetector(ABC)`.

Thus by inheriting from ABC, we explicitly declare this as an abstract base class. 

This makes the intention clearer and provides better support for abstract methods.

Replaced raise `NotImplementedError(...)` with `@abstractmethod` decorator.

The `@abstractmethod` decorator is more idiomatic in Python for defining abstract methods. It prevents instantiation of any subclass that doesn't implement these methods, which is more robust than raising an error at runtime.

Cheers,
Michael Mendy.